### PR TITLE
Add a color scheme to extended-colorschemes snippet

### DIFF
--- a/snippets/extended-colorschemes.css
+++ b/snippets/extended-colorschemes.css
@@ -73,6 +73,9 @@ settings:
             label: Rosebox
             value: ctp-rosebox
         -
+            label: Royal Velvet
+            value: ctp-royal-velvet
+        -
             label: Solarized
             value: ctp-solarized-dark
 */
@@ -105,33 +108,33 @@ settings:
   --ctp-crust: 25, 25, 25;
 }
 .theme-light.anp-theme-ext-light.ctp-nord-light {
-    --ctp-rosewater: 209, 135, 112;
-    --ctp-flamingo: 180, 142, 173;
-    --ctp-pink: 180, 142, 173;
-    --ctp-mauve: 180, 142, 173;
-    --ctp-red: 191, 97, 106;
-    --ctp-maroon: 191, 97, 106;
-    --ctp-peach: 208, 135, 112;
-    --ctp-yellow: 216, 172, 84;
-    --ctp-green: 136, 167, 108;
-    --ctp-teal: 121, 191, 142;
-    --ctp-sky: 143, 188, 187;
-    --ctp-sapphire: 136, 192, 208;
-    --ctp-blue: 94, 129, 172;
-    --ctp-lavender: 94, 129, 172;
-    --ctp-text: 46, 52, 64;
-    --ctp-subtext1: 59, 66, 82;
-    --ctp-subtext0: 67, 76, 94;
-    --ctp-overlay2: 76, 86, 106;
-    --ctp-overlay1: 86, 97, 118;
-    --ctp-overlay0: 143, 188, 187;
-    --ctp-surface2: 216, 222, 233;
-    --ctp-surface1: 216, 222, 233;
-    --ctp-surface0: 229, 233, 240;
-    --ctp-crust: 229, 233, 240;
-    --ctp-mantle: 231, 235, 241;
-    --ctp-base: 236, 239, 244;
-    --ctp-accent: 136, 192, 208;
+  --ctp-rosewater: 209, 135, 112;
+  --ctp-flamingo: 180, 142, 173;
+  --ctp-pink: 180, 142, 173;
+  --ctp-mauve: 180, 142, 173;
+  --ctp-red: 191, 97, 106;
+  --ctp-maroon: 191, 97, 106;
+  --ctp-peach: 208, 135, 112;
+  --ctp-yellow: 216, 172, 84;
+  --ctp-green: 136, 167, 108;
+  --ctp-teal: 121, 191, 142;
+  --ctp-sky: 143, 188, 187;
+  --ctp-sapphire: 136, 192, 208;
+  --ctp-blue: 94, 129, 172;
+  --ctp-lavender: 94, 129, 172;
+  --ctp-text: 46, 52, 64;
+  --ctp-subtext1: 59, 66, 82;
+  --ctp-subtext0: 67, 76, 94;
+  --ctp-overlay2: 76, 86, 106;
+  --ctp-overlay1: 86, 97, 118;
+  --ctp-overlay0: 143, 188, 187;
+  --ctp-surface2: 216, 222, 233;
+  --ctp-surface1: 216, 222, 233;
+  --ctp-surface0: 229, 233, 240;
+  --ctp-crust: 229, 233, 240;
+  --ctp-mantle: 231, 235, 241;
+  --ctp-base: 236, 239, 244;
+  --ctp-accent: 136, 192, 208;
 }
 .theme-dark.anp-theme-ext-dark.ctp-dracula {
   --ctp-rosewater: 246, 201, 153;
@@ -355,7 +358,7 @@ settings:
   --ctp-surface2: 214, 196, 161;
   --ctp-surface1: 235, 219, 179;
   --ctp-surface0: 242, 229, 188;
-  --ctp-base: 249,245,215;
+  --ctp-base: 249, 245, 215;
   --ctp-mantle: 236, 225, 196;
   --ctp-crust: 230, 215, 178;
 }
@@ -506,6 +509,34 @@ settings:
   --ctp-surface0: 52, 43, 35;
   --ctp-base: 44, 38, 33;
   --ctp-mantle: 38, 33, 28;
-  --ctp-crust: 35, 30, 26; 
+  --ctp-crust: 35, 30, 26;
   --ctp-accent: var(--ctp-yellow);
+}
+.theme-dark.anp-theme-ext-dark.ctp-royal-velvet {
+  --ctp-rosewater: 246, 201, 153;
+  --ctp-flamingo: 245, 189, 166;
+  --ctp-pink: 228, 157, 248;
+  --ctp-mauve: 197, 146, 222;
+  --ctp-red: 240, 120, 160;
+  --ctp-maroon: 230, 102, 102;
+  --ctp-peach: 230, 195, 125;
+  --ctp-yellow: 241, 250, 140;
+  --ctp-green: 130, 235, 130;
+  --ctp-teal: 114, 224, 214;
+  --ctp-sky: 139, 233, 253;
+  --ctp-sapphire: 104, 197, 240;
+  --ctp-blue: 95, 126, 222;
+  --ctp-lavender: 154, 141, 247;
+  --ctp-text: 248, 248, 242;
+  --ctp-subtext1: 211, 211, 197;
+  --ctp-subtext0: 191, 191, 181;
+  --ctp-overlay2: 139, 143, 167;
+  --ctp-overlay1: 110, 114, 145;
+  --ctp-overlay0: 88, 92, 116;
+  --ctp-surface2: 68, 71, 90;
+  --ctp-surface1: 56, 59, 76;
+  --ctp-surface0: 48, 50, 65;
+  --ctp-base: 30, 30, 36;
+  --ctp-mantle: 25, 25, 30;
+  --ctp-crust: 20, 20, 25;
 }


### PR DESCRIPTION
Add a color scheme to the extended colorschemes snippet inspired by the Royal Velvet theme, except it's slightly darker and doesn't support the original's theme grandient titles.

The result ends up to be pretty close to Dracula.

... and it seems I might have "fixed" some inconsistancies with tabulations and removed an extra space at the end of a line. I blame VS Code auto-formating for the extra unwanted editing. :)