### PR TITLE
File icons and ext

### DIFF
--- a/src/modules/Base/general-ui.scss
+++ b/src/modules/Base/general-ui.scss
@@ -55,3 +55,8 @@
 .anp-card-layout .mod-vertical .workspace-tabs {
   background-color: var(--tab-container-background);
 }
+/* Align file extension labels to the right in sidebar */
+.nav-file-title-content,
+.nav-folder-title-content {
+  flex-grow: 1;
+}

--- a/src/modules/Features/file-icons.scss
+++ b/src/modules/Features/file-icons.scss
@@ -9,8 +9,7 @@
   width: 16px;
   margin-right: 5px;
 }
-.anp-file-icons .nav-file .nav-file-title[data-path$=".md"]::before,
-.anp-file-icons .nav-file .nav-file-title[data-path$=".txt"]::before {
+.anp-file-icons .nav-file .nav-file-title[data-path$=".md"]::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpath d='M14 2v6h6m-4 5H8m8 4H8m2-8H8'/%3E%3C/svg%3E%0A");
   -webkit-mask-repeat: no-repeat;
 }

--- a/src/modules/Features/file-icons.scss
+++ b/src/modules/Features/file-icons.scss
@@ -18,6 +18,8 @@
  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' data-darkreader-inline-stroke='' style='--darkreader-inline-stroke:currentColor;'%3E%3Crect x='3' y='3' width='7' height='9'%3E%3C/rect%3E%3Crect x='14' y='3' width='7' height='5'%3E%3C/rect%3E%3Crect x='14' y='12' width='7' height='9'%3E%3C/rect%3E%3Crect x='3' y='16' width='7' height='5'%3E%3C/rect%3E%3C/svg%3E");
   -webkit-mask-repeat: no-repeat;
 }
+.anp-file-icons .nav-file .nav-file-title[data-path$=".svg"]::before,
+.anp-file-icons .nav-file .nav-file-title[data-path$=".bmp"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".jpg"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".gif"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".webp"]::before,

--- a/src/modules/Features/file-icons.scss
+++ b/src/modules/Features/file-icons.scss
@@ -15,7 +15,7 @@
   -webkit-mask-repeat: no-repeat;
 }
 .anp-file-icons .nav-file .nav-file-title[data-path$=".canvas"]::before {
- -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' data-darkreader-inline-stroke='' style='--darkreader-inline-stroke:currentColor;'%3E%3Crect x='3' y='3' width='7' height='9'%3E%3C/rect%3E%3Crect x='14' y='3' width='7' height='5'%3E%3C/rect%3E%3Crect x='14' y='12' width='7' height='9'%3E%3C/rect%3E%3Crect x='3' y='16' width='7' height='5'%3E%3C/rect%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 3h7v9H3zm11 0h7v5h-7zm0 9h7v9h-7zM3 16h7v5H3z'/%3E%3C/svg%3E");
   -webkit-mask-repeat: no-repeat;
 }
 .anp-file-icons .nav-file .nav-file-title[data-path$=".svg"]::before,

--- a/src/modules/Features/file-icons.scss
+++ b/src/modules/Features/file-icons.scss
@@ -26,6 +26,26 @@
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpath d='M14 2v6h6'/%3E%3Ccircle cx='10' cy='13' r='2'/%3E%3Cpath d='m20 17-1.09-1.09a2 2 0 0 0-2.82 0L10 22'/%3E%3C/svg%3E%0A");
   -webkit-mask-repeat: no-repeat;
 }
+.anp-file-icons .nav-file .nav-file-title[data-path$=".mp3"]::before,
+.anp-file-icons .nav-file .nav-file-title[data-path$=".wav"]::before,
+.anp-file-icons .nav-file .nav-file-title[data-path$=".m4a"]::before,
+.anp-file-icons .nav-file .nav-file-title[data-path$=".ogg"]::before,
+.anp-file-icons .nav-file .nav-file-title[data-path$=".flac"]::before,
+.anp-file-icons .nav-file .nav-file-title[data-path$=".3gp"]::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 18V5l12-2v13M9 9l12-2'/%3E%3Ccircle cx='6' cy='18' r='3'/%3E%3Ccircle cx='18' cy='16' r='3'/%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+}
+.anp-file-icons .nav-file .nav-file-title[data-path$=".webm"]::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M10 8l6 4-6 4V8z'/%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+}
+.anp-file-icons .nav-file .nav-file-title[data-path$=".mp4"]::before,
+.anp-file-icons .nav-file .nav-file-title[data-path$=".ogv"]::before,
+.anp-file-icons .nav-file .nav-file-title[data-path$=".mov"]::before,
+.anp-file-icons .nav-file .nav-file-title[data-path$=".mkv"]::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 11v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8H4Z'/%3E%3Cpath d='m4 11-.88-2.87a2 2 0 0 1 1.33-2.5l11.48-3.5a2 2 0 0 1 2.5 1.32l.87 2.87L4 11.01Z'/%3E%3Cpath d='M6.6 4.99l3.38 4.2m1.88-5.81l3.38 4.2'/%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+}
 .anp-file-icons .nav-folder.mod-root > .nav-folder-children > .nav-file .nav-file-title {
   padding-left: var(--size-4-2);
 }


### PR DESCRIPTION
**Note: CSS has not been built!**

- Added icon to SVG and BMP files
- Added icons for supported audio and video files
- Aligned file extension labels to the right in the sidebar
- Reduced stroke width of canvas icon to 1.5 (from 2)
- Removed icon for unsupported txt files

<img width="297" alt="image" src="https://user-images.githubusercontent.com/134939/211473377-48b45bf4-b203-4339-aaca-dd233960d2d8.png">