### PR TITLE
fix titlebar drag when kanban title autohides

### DIFF
--- a/src/modules/Note/tabtitlebar.scss
+++ b/src/modules/Note/tabtitlebar.scss
@@ -35,6 +35,9 @@
   .workspace-leaf-content .view-header:is(:hover,:focus-within) + .view-content {
     transform: translateY(var(--title-bar-translate-y));
   }
+  .workspace-leaf-content .view-header:not(:hover,:focus-within) .view-actions .clickable-icon {
+    app-region: drag;
+  }
   .view-header::before {
     z-index: 0;
   }


### PR DESCRIPTION
Kanban boards have a set of icons on the right of the tab's title bar. When the tab title bar autohides, these toolbar icons prevent you from dragging the Obsidian window on the right side of the Application title bar. 

This PR fixes it.

---

These are the Kanban toolbar icons:

<img width="357" alt="image" src="https://user-images.githubusercontent.com/134939/212827145-6354f399-00f5-4f04-aeec-7ac6433b1870.png">

And here are the Kanban toolbar icons when the tab titlebar is hidden, preventing drag:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/134939/212826382-d9824a04-cbd7-4143-a42a-2c17c4a21053.png">