### PR TITLE
fix input hint position and size on mobile

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -5682,20 +5682,25 @@ None of the original code was used and the feature was implemented from scratch.
   position: relative;
 }
 .style-settings-container .setting-item-control:has(input[type=text])::after {
-  align-self: center;
+  align-items: center;
   background-color: var(--background-modifier-hover);
   border-radius: var(--radius-s);
+  display: flex;
   font-size: 10px;
   font-weight: var(--font-semibold);
+  height: calc(var(--input-height) - 12px);
+  justify-content: center;
+  left: calc(100% - 68px);
   letter-spacing: 0.05em;
   line-height: var(--line-height-normal);
   padding: 0;
-  text-transform: uppercase;
-  text-align: center;
   position: absolute;
-  top: 8px;
-  left: calc(100% - 65px);
+  text-transform: uppercase;
+  top: 6px;
   width: 28px;
+}
+.is-mobile .style-settings-container .setting-item-control:has(input[type=text])::after {
+  top: 4px;
 }
 
 .style-settings-container .setting-item:is([data-id=tag-border-width],

--- a/obsidian.css
+++ b/obsidian.css
@@ -300,7 +300,7 @@ settings:
   -
     id: anp-editor-header
     title: File Editor & Markdown Elements
-    description: Active Line Highlight, Callouts, Checkboxes, Codeblocks, Lists, Tables
+    description: Callouts, Checkboxes, Codeblocks, Lists, Tables, Tags, etc.
     type: heading
     level: 1
     collapsed: true

--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -299,7 +299,7 @@ settings:
   -
     id: anp-editor-header
     title: File Editor & Markdown Elements
-    description: Active Line Highlight, Callouts, Checkboxes, Codeblocks, Lists, Tables
+    description: Callouts, Checkboxes, Codeblocks, Lists, Tables, Tags, etc.
     type: heading
     level: 1
     collapsed: true

--- a/src/modules/Plugins/style-settings.scss
+++ b/src/modules/Plugins/style-settings.scss
@@ -87,22 +87,28 @@
   flex-grow: 0;
   position: relative;
   &::after {
-    align-self: center;
+    align-items: center;
     background-color: var(--background-modifier-hover);
     border-radius: var(--radius-s);
+    display: flex;
     font-size: 10px;
     font-weight: var(--font-semibold);
+    height: calc(var(--input-height) - 12px);
+    justify-content: center;
+    left: calc(100% - 68px);
     letter-spacing: 0.05em;
     line-height: var(--line-height-normal);
     padding: 0;
-    text-transform: uppercase;
-    text-align: center;
     position: absolute;
-    top: 8px;
-    left: calc(100% - 65px);
+    text-transform: uppercase;
+    top: 6px;
     width: 28px;
+    .is-mobile & {
+      top: 4px;
+    }
   }
 }
+
 .style-settings-container .setting-item:is(
   [data-id="tag-border-width"],
   [data-id="callout-radius"],

--- a/theme.css
+++ b/theme.css
@@ -5682,20 +5682,25 @@ None of the original code was used and the feature was implemented from scratch.
   position: relative;
 }
 .style-settings-container .setting-item-control:has(input[type=text])::after {
-  align-self: center;
+  align-items: center;
   background-color: var(--background-modifier-hover);
   border-radius: var(--radius-s);
+  display: flex;
   font-size: 10px;
   font-weight: var(--font-semibold);
+  height: calc(var(--input-height) - 12px);
+  justify-content: center;
+  left: calc(100% - 68px);
   letter-spacing: 0.05em;
   line-height: var(--line-height-normal);
   padding: 0;
-  text-transform: uppercase;
-  text-align: center;
   position: absolute;
-  top: 8px;
-  left: calc(100% - 65px);
+  text-transform: uppercase;
+  top: 6px;
   width: 28px;
+}
+.is-mobile .style-settings-container .setting-item-control:has(input[type=text])::after {
+  top: 4px;
 }
 
 .style-settings-container .setting-item:is([data-id=tag-border-width],

--- a/theme.css
+++ b/theme.css
@@ -300,7 +300,7 @@ settings:
   -
     id: anp-editor-header
     title: File Editor & Markdown Elements
-    description: Active Line Highlight, Callouts, Checkboxes, Codeblocks, Lists, Tables
+    description: Callouts, Checkboxes, Codeblocks, Lists, Tables, Tags, etc.
     type: heading
     level: 1
     collapsed: true


### PR DESCRIPTION
On Computer:

<img width="544" alt="image" src="https://user-images.githubusercontent.com/134939/215346391-a3bdae9d-694f-48dd-9e7b-a8709759774c.png">

On Mobile:

![IMG_1941](https://user-images.githubusercontent.com/134939/215346425-8b87759e-b709-4ef4-9cec-8ea717b078e2.PNG)
