### PR TITLE
Refactor links in theme settings

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -5753,7 +5753,7 @@ None of the original code was used and the feature was implemented from scratch.
   font-size: var(--font-ui-small);
   margin-top: var(--size-4-1);
   padding: 0;
-  user-select: all;
+  -webkit-user-select: all;
 }
 .setting-item:is([data-id^=anuppuccin-url-]) .setting-item-description > div {
   display: none;

--- a/obsidian.css
+++ b/obsidian.css
@@ -108,7 +108,7 @@ settings:
     title: Download the Extended Color Schemes
     description: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/snippets/extended-colorschemes.css
     type: variable-text
-    default: ''
+    default: '0'
 
 # Colors :: Color Overrides
 
@@ -681,7 +681,7 @@ settings:
     title: Download the Minimal Cards Snippet
     description: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/cards.scss
     type: variable-text
-    default: ''
+    default: '0'
   -
     id: cards-min-width
     title: Card minimum width
@@ -2121,19 +2121,19 @@ settings:
     title: Buy Me a Coffee
     description: https://www.buymeacoffee.com/anubisnekhet
     type: variable-text
-    default: ''
+    default: '0'
   -
     id: anuppuccin-url-star-repo
     title: Star the Theme on GitHub
     description: https://github.com/anubisnekhet/anuppuccin
     type: variable-text
-    default: ''
+    default: '0'
   -
     id: anuppuccin-url-submit-issue
     title: Submit an Issue on GitHub
     description: https://github.com/anubisnekhet/anuppuccin/issues
     type: variable-text
-    default: ''
+    default: '0'
 
 */
 /*------------------Defining Colorschemes-------------------*/
@@ -5754,6 +5754,9 @@ None of the original code was used and the feature was implemented from scratch.
   margin-top: var(--size-4-1);
   padding: 0;
   user-select: all;
+}
+.setting-item:is([data-id^=anuppuccin-url-]) .setting-item-description > div {
+  display: none;
 }
 
 .setting-item[data-id=anuppuccin-url-donate] .setting-item-name::before {

--- a/obsidian.css
+++ b/obsidian.css
@@ -104,11 +104,11 @@ settings:
     type: class-toggle
     default: true
   -
-    id: anuppuccin-extended-colorschemes-links
-    title: Extended Color Schemes
-    description: "Download the extended color schemes snippet from here"
+    id: anuppuccin-url-extended-colorschemes
+    title: Download the Extended Color Schemes
+    description: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/snippets/extended-colorschemes.css
     type: variable-text
-    default: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/snippets/extended-colorschemes.css
+    default: ''
 
 # Colors :: Color Overrides
 
@@ -677,11 +677,11 @@ settings:
     level: 2
     collapsed: true
   -
-    id: anp-snippet-minimal-cards-disclaimer
-    title: Minimal Cards Snippet
-    description: "Download the Minimal Cards snippet from here"
+    id: anuppuccin-url-minimal-cards-snippet
+    title: Download the Minimal Cards Snippet
+    description: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/cards.scss
     type: variable-text
-    default: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/cards.scss
+    default: ''
   -
     id: cards-min-width
     title: Card minimum width
@@ -2110,24 +2110,30 @@ settings:
 # Credits
 
   -
-    id: anuppuccin-theme-credits
+    id: anuppuccin-support
     title: Support AnuPpuccin
-    description: If you like the theme, you can buy me a coffee!
+    description: If you like the theme, here are some ways to support development
     type: heading
     level: 1
     collapsed: true
   -
-    id: anuppuccin-theme-donate
-    title: Donate Link
-    description: "Buy me a coffee here:"
+    id: anuppuccin-url-donate
+    title: Buy Me a Coffee
+    description: https://www.buymeacoffee.com/anubisnekhet
     type: variable-text
-    default: https://www.buymeacoffee.com/anubisnekhet
+    default: ''
   -
-    id: anuppuccin-theme-source
-    title: Source Code
-    description: "View and contribute to the theme here:"
+    id: anuppuccin-url-star-repo
+    title: Star the Theme on GitHub
+    description: https://github.com/anubisnekhet/anuppuccin
     type: variable-text
-    default: https://github.com/anubisnekhet/anuppuccin
+    default: ''
+  -
+    id: anuppuccin-url-submit-issue
+    title: Submit an Issue on GitHub
+    description: https://github.com/anubisnekhet/anuppuccin/issues
+    type: variable-text
+    default: ''
 
 */
 /*------------------Defining Colorschemes-------------------*/
@@ -5643,7 +5649,7 @@ None of the original code was used and the feature was implemented from scratch.
   border-color: rgba(var(--ctp-accent), 0.2);
 }
 
-.style-settings-container .style-settings-heading[data-id=anuppuccin-theme-credits] .setting-item-name {
+.style-settings-container .style-settings-heading[data-id=anuppuccin-support] .setting-item-name {
   color: var(--color-accent) !important;
 }
 
@@ -5727,6 +5733,39 @@ None of the original code was used and the feature was implemented from scratch.
 .setting-item[data-id=anp-colors-section-header] > .setting-item-info > .setting-item-name {
   border-bottom: 2px solid;
   border-image: linear-gradient(to right, rgb(var(--ctp-rosewater)) 7%, rgb(var(--ctp-flamingo)) 7%, rgb(var(--ctp-flamingo)) 14%, rgb(var(--ctp-mauve)) 14%, rgb(var(--ctp-mauve)) 21%, rgb(var(--ctp-pink)) 21%, rgb(var(--ctp-pink)) 28%, rgb(var(--ctp-red)) 28%, rgb(var(--ctp-red)) 35%, rgb(var(--ctp-maroon)) 35%, rgb(var(--ctp-maroon)) 42%, rgb(var(--ctp-peach)) 42%, rgb(var(--ctp-peach)) 49%, rgb(var(--ctp-yellow)) 49%, rgb(var(--ctp-yellow)) 56%, rgb(var(--ctp-green)) 56%, rgb(var(--ctp-green)) 63%, rgb(var(--ctp-teal)) 63%, rgb(var(--ctp-teal)) 70%, rgb(var(--ctp-sky)) 70%, rgb(var(--ctp-sky)) 77%, rgb(var(--ctp-sapphire)) 77%, rgb(var(--ctp-sapphire)) 85%, rgb(var(--ctp-blue)) 85%, rgb(var(--ctp-blue)) 92%, rgb(var(--ctp-lavender))) 5;
+}
+
+.setting-item:is([data-id^=anuppuccin-url-]) .setting-item-control {
+  display: none;
+}
+.setting-item:is([data-id^=anuppuccin-url-]) .setting-item-name::before {
+  display: inline-flex;
+  font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  height: fit-content;
+  padding-right: var(--size-4-2);
+  width: var(--size-4-4);
+}
+.setting-item:is([data-id^=anuppuccin-url-]) .setting-item-description {
+  align-items: center;
+  color: var(--color-accent);
+  cursor: text;
+  display: flex;
+  font-size: var(--font-ui-small);
+  margin-top: var(--size-4-1);
+  padding: 0;
+  user-select: all;
+}
+
+.setting-item[data-id=anuppuccin-url-donate] .setting-item-name::before {
+  content: "☕";
+}
+
+.setting-item[data-id=anuppuccin-url-star-repo] .setting-item-name::before {
+  content: "⭐";
+}
+
+.setting-item[data-id=anuppuccin-url-submit-issue] .setting-item-name::before {
+  content: "🐞";
 }
 
 /*-Fix dataview table header size-*/

--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -103,11 +103,11 @@ settings:
     type: class-toggle
     default: true
   -
-    id: anuppuccin-extended-colorschemes-links
-    title: Extended Color Schemes
-    description: "Download the extended color schemes snippet from here"
+    id: anuppuccin-url-extended-colorschemes
+    title: Download the Extended Color Schemes
+    description: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/snippets/extended-colorschemes.css
     type: variable-text
-    default: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/snippets/extended-colorschemes.css
+    default: ''
 
 # Colors :: Color Overrides
 
@@ -676,11 +676,11 @@ settings:
     level: 2
     collapsed: true
   -
-    id: anp-snippet-minimal-cards-disclaimer
-    title: Minimal Cards Snippet
-    description: "Download the Minimal Cards snippet from here"
+    id: anuppuccin-url-minimal-cards-snippet
+    title: Download the Minimal Cards Snippet
+    description: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/cards.scss
     type: variable-text
-    default: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/cards.scss
+    default: ''
   -
     id: cards-min-width
     title: Card minimum width
@@ -2109,23 +2109,29 @@ settings:
 # Credits
 
   -
-    id: anuppuccin-theme-credits
+    id: anuppuccin-support
     title: Support AnuPpuccin
-    description: If you like the theme, you can buy me a coffee!
+    description: If you like the theme, here are some ways to support development
     type: heading
     level: 1
     collapsed: true
   -
-    id: anuppuccin-theme-donate
-    title: Donate Link
-    description: "Buy me a coffee here:"
+    id: anuppuccin-url-donate
+    title: Buy Me a Coffee
+    description: https://www.buymeacoffee.com/anubisnekhet
     type: variable-text
-    default: https://www.buymeacoffee.com/anubisnekhet
+    default: ''
   -
-    id: anuppuccin-theme-source
-    title: Source Code
-    description: "View and contribute to the theme here:"
+    id: anuppuccin-url-star-repo
+    title: Star the Theme on GitHub
+    description: https://github.com/anubisnekhet/anuppuccin
     type: variable-text
-    default: https://github.com/anubisnekhet/anuppuccin
+    default: ''
+  -
+    id: anuppuccin-url-submit-issue
+    title: Submit an Issue on GitHub
+    description: https://github.com/anubisnekhet/anuppuccin/issues
+    type: variable-text
+    default: ''
 
 */

--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -107,7 +107,7 @@ settings:
     title: Download the Extended Color Schemes
     description: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/snippets/extended-colorschemes.css
     type: variable-text
-    default: ''
+    default: '0'
 
 # Colors :: Color Overrides
 
@@ -680,7 +680,7 @@ settings:
     title: Download the Minimal Cards Snippet
     description: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/cards.scss
     type: variable-text
-    default: ''
+    default: '0'
   -
     id: cards-min-width
     title: Card minimum width
@@ -2120,18 +2120,18 @@ settings:
     title: Buy Me a Coffee
     description: https://www.buymeacoffee.com/anubisnekhet
     type: variable-text
-    default: ''
+    default: '0'
   -
     id: anuppuccin-url-star-repo
     title: Star the Theme on GitHub
     description: https://github.com/anubisnekhet/anuppuccin
     type: variable-text
-    default: ''
+    default: '0'
   -
     id: anuppuccin-url-submit-issue
     title: Submit an Issue on GitHub
     description: https://github.com/anubisnekhet/anuppuccin/issues
     type: variable-text
-    default: ''
+    default: '0'
 
 */

--- a/src/modules/Plugins/style-settings.scss
+++ b/src/modules/Plugins/style-settings.scss
@@ -169,7 +169,7 @@
     font-size: var(--font-ui-small);
     margin-top: var(--size-4-1);
     padding: 0;
-    user-select: all;
+    -webkit-user-select: all;
     > div {
       display: none;
     }

--- a/src/modules/Plugins/style-settings.scss
+++ b/src/modules/Plugins/style-settings.scss
@@ -170,6 +170,9 @@
     margin-top: var(--size-4-1);
     padding: 0;
     user-select: all;
+    > div {
+      display: none;
+    }
   }
 }
 .setting-item[data-id="anuppuccin-url-donate"] .setting-item-name::before {

--- a/src/modules/Plugins/style-settings.scss
+++ b/src/modules/Plugins/style-settings.scss
@@ -154,6 +154,13 @@
   .setting-item-control {
     display: none;
   }
+  .setting-item-name::before {
+    display: inline-flex;
+    font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    height: fit-content;
+    padding-right: var(--size-4-2);
+    width: var(--size-4-4);
+  }
   .setting-item-description {
     align-items: center;
     color: var(--color-accent);
@@ -164,4 +171,13 @@
     padding: 0;
     user-select: all;
   }
+}
+.setting-item[data-id="anuppuccin-url-donate"] .setting-item-name::before {
+  content: '\2615'; // coffee
+}
+.setting-item[data-id="anuppuccin-url-star-repo"] .setting-item-name::before {
+  content: '\2b50'; // star
+}
+.setting-item[data-id="anuppuccin-url-submit-issue"] .setting-item-name::before {
+  content: '\1f41e'; // bug
 }

--- a/src/modules/Plugins/style-settings.scss
+++ b/src/modules/Plugins/style-settings.scss
@@ -60,7 +60,7 @@
   }
 }
 
-.style-settings-container .style-settings-heading[data-id="anuppuccin-theme-credits"] .setting-item-name {
+.style-settings-container .style-settings-heading[data-id="anuppuccin-support"] .setting-item-name {
   color: var(--color-accent) !important;
 }
 

--- a/src/modules/Plugins/style-settings.scss
+++ b/src/modules/Plugins/style-settings.scss
@@ -149,3 +149,19 @@
   border-bottom: 2px solid;
   border-image: linear-gradient(to right, rgb(var(--ctp-rosewater)) 7%, rgb(var(--ctp-flamingo)) 7%, rgb(var(--ctp-flamingo)) 14%, rgb(var(--ctp-mauve)) 14%, rgb(var(--ctp-mauve)) 21%, rgb(var(--ctp-pink)) 21%, rgb(var(--ctp-pink)) 28%, rgb(var(--ctp-red)) 28%, rgb(var(--ctp-red)) 35%, rgb(var(--ctp-maroon)) 35%, rgb(var(--ctp-maroon)) 42%, rgb(var(--ctp-peach)) 42%, rgb(var(--ctp-peach)) 49%, rgb(var(--ctp-yellow)) 49%, rgb(var(--ctp-yellow)) 56%, rgb(var(--ctp-green)) 56%, rgb(var(--ctp-green)) 63%, rgb(var(--ctp-teal)) 63%, rgb(var(--ctp-teal)) 70%, rgb(var(--ctp-sky)) 70%, rgb(var(--ctp-sky)) 77%, rgb(var(--ctp-sapphire)) 77%, rgb(var(--ctp-sapphire)) 85%, rgb(var(--ctp-blue)) 85%, rgb(var(--ctp-blue)) 92%, rgb( var(--ctp-lavender))) 5;
 }
+
+.setting-item:is([data-id^="anuppuccin-url-"]) {
+  .setting-item-control {
+    display: none;
+  }
+  .setting-item-description {
+    align-items: center;
+    color: var(--color-accent);
+    cursor: text;
+    display: flex;
+    font-size: var(--font-ui-small);
+    margin-top: var(--size-4-1);
+    padding: 0;
+    user-select: all;
+  }
+}

--- a/theme.css
+++ b/theme.css
@@ -5753,7 +5753,7 @@ None of the original code was used and the feature was implemented from scratch.
   font-size: var(--font-ui-small);
   margin-top: var(--size-4-1);
   padding: 0;
-  user-select: all;
+  -webkit-user-select: all;
 }
 .setting-item:is([data-id^=anuppuccin-url-]) .setting-item-description > div {
   display: none;

--- a/theme.css
+++ b/theme.css
@@ -108,7 +108,7 @@ settings:
     title: Download the Extended Color Schemes
     description: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/snippets/extended-colorschemes.css
     type: variable-text
-    default: ''
+    default: '0'
 
 # Colors :: Color Overrides
 
@@ -681,7 +681,7 @@ settings:
     title: Download the Minimal Cards Snippet
     description: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/cards.scss
     type: variable-text
-    default: ''
+    default: '0'
   -
     id: cards-min-width
     title: Card minimum width
@@ -2121,19 +2121,19 @@ settings:
     title: Buy Me a Coffee
     description: https://www.buymeacoffee.com/anubisnekhet
     type: variable-text
-    default: ''
+    default: '0'
   -
     id: anuppuccin-url-star-repo
     title: Star the Theme on GitHub
     description: https://github.com/anubisnekhet/anuppuccin
     type: variable-text
-    default: ''
+    default: '0'
   -
     id: anuppuccin-url-submit-issue
     title: Submit an Issue on GitHub
     description: https://github.com/anubisnekhet/anuppuccin/issues
     type: variable-text
-    default: ''
+    default: '0'
 
 */
 /*------------------Defining Colorschemes-------------------*/
@@ -5754,6 +5754,9 @@ None of the original code was used and the feature was implemented from scratch.
   margin-top: var(--size-4-1);
   padding: 0;
   user-select: all;
+}
+.setting-item:is([data-id^=anuppuccin-url-]) .setting-item-description > div {
+  display: none;
 }
 
 .setting-item[data-id=anuppuccin-url-donate] .setting-item-name::before {

--- a/theme.css
+++ b/theme.css
@@ -104,11 +104,11 @@ settings:
     type: class-toggle
     default: true
   -
-    id: anuppuccin-extended-colorschemes-links
-    title: Extended Color Schemes
-    description: "Download the extended color schemes snippet from here"
+    id: anuppuccin-url-extended-colorschemes
+    title: Download the Extended Color Schemes
+    description: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/snippets/extended-colorschemes.css
     type: variable-text
-    default: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/snippets/extended-colorschemes.css
+    default: ''
 
 # Colors :: Color Overrides
 
@@ -677,11 +677,11 @@ settings:
     level: 2
     collapsed: true
   -
-    id: anp-snippet-minimal-cards-disclaimer
-    title: Minimal Cards Snippet
-    description: "Download the Minimal Cards snippet from here"
+    id: anuppuccin-url-minimal-cards-snippet
+    title: Download the Minimal Cards Snippet
+    description: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/cards.scss
     type: variable-text
-    default: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/cards.scss
+    default: ''
   -
     id: cards-min-width
     title: Card minimum width
@@ -2110,24 +2110,30 @@ settings:
 # Credits
 
   -
-    id: anuppuccin-theme-credits
+    id: anuppuccin-support
     title: Support AnuPpuccin
-    description: If you like the theme, you can buy me a coffee!
+    description: If you like the theme, here are some ways to support development
     type: heading
     level: 1
     collapsed: true
   -
-    id: anuppuccin-theme-donate
-    title: Donate Link
-    description: "Buy me a coffee here:"
+    id: anuppuccin-url-donate
+    title: Buy Me a Coffee
+    description: https://www.buymeacoffee.com/anubisnekhet
     type: variable-text
-    default: https://www.buymeacoffee.com/anubisnekhet
+    default: ''
   -
-    id: anuppuccin-theme-source
-    title: Source Code
-    description: "View and contribute to the theme here:"
+    id: anuppuccin-url-star-repo
+    title: Star the Theme on GitHub
+    description: https://github.com/anubisnekhet/anuppuccin
     type: variable-text
-    default: https://github.com/anubisnekhet/anuppuccin
+    default: ''
+  -
+    id: anuppuccin-url-submit-issue
+    title: Submit an Issue on GitHub
+    description: https://github.com/anubisnekhet/anuppuccin/issues
+    type: variable-text
+    default: ''
 
 */
 /*------------------Defining Colorschemes-------------------*/
@@ -5643,7 +5649,7 @@ None of the original code was used and the feature was implemented from scratch.
   border-color: rgba(var(--ctp-accent), 0.2);
 }
 
-.style-settings-container .style-settings-heading[data-id=anuppuccin-theme-credits] .setting-item-name {
+.style-settings-container .style-settings-heading[data-id=anuppuccin-support] .setting-item-name {
   color: var(--color-accent) !important;
 }
 
@@ -5727,6 +5733,39 @@ None of the original code was used and the feature was implemented from scratch.
 .setting-item[data-id=anp-colors-section-header] > .setting-item-info > .setting-item-name {
   border-bottom: 2px solid;
   border-image: linear-gradient(to right, rgb(var(--ctp-rosewater)) 7%, rgb(var(--ctp-flamingo)) 7%, rgb(var(--ctp-flamingo)) 14%, rgb(var(--ctp-mauve)) 14%, rgb(var(--ctp-mauve)) 21%, rgb(var(--ctp-pink)) 21%, rgb(var(--ctp-pink)) 28%, rgb(var(--ctp-red)) 28%, rgb(var(--ctp-red)) 35%, rgb(var(--ctp-maroon)) 35%, rgb(var(--ctp-maroon)) 42%, rgb(var(--ctp-peach)) 42%, rgb(var(--ctp-peach)) 49%, rgb(var(--ctp-yellow)) 49%, rgb(var(--ctp-yellow)) 56%, rgb(var(--ctp-green)) 56%, rgb(var(--ctp-green)) 63%, rgb(var(--ctp-teal)) 63%, rgb(var(--ctp-teal)) 70%, rgb(var(--ctp-sky)) 70%, rgb(var(--ctp-sky)) 77%, rgb(var(--ctp-sapphire)) 77%, rgb(var(--ctp-sapphire)) 85%, rgb(var(--ctp-blue)) 85%, rgb(var(--ctp-blue)) 92%, rgb(var(--ctp-lavender))) 5;
+}
+
+.setting-item:is([data-id^=anuppuccin-url-]) .setting-item-control {
+  display: none;
+}
+.setting-item:is([data-id^=anuppuccin-url-]) .setting-item-name::before {
+  display: inline-flex;
+  font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  height: fit-content;
+  padding-right: var(--size-4-2);
+  width: var(--size-4-4);
+}
+.setting-item:is([data-id^=anuppuccin-url-]) .setting-item-description {
+  align-items: center;
+  color: var(--color-accent);
+  cursor: text;
+  display: flex;
+  font-size: var(--font-ui-small);
+  margin-top: var(--size-4-1);
+  padding: 0;
+  user-select: all;
+}
+
+.setting-item[data-id=anuppuccin-url-donate] .setting-item-name::before {
+  content: "☕";
+}
+
+.setting-item[data-id=anuppuccin-url-star-repo] .setting-item-name::before {
+  content: "⭐";
+}
+
+.setting-item[data-id=anuppuccin-url-submit-issue] .setting-item-name::before {
+  content: "🐞";
 }
 
 /*-Fix dataview table header size-*/


### PR DESCRIPTION
I wasn't happy with using a text input for links so I found (I think) a better solution:

## Links look like hyperlinks and are fully visible

<img width="765" alt="image" src="https://user-images.githubusercontent.com/134939/215671158-e23fdb4e-9b51-4910-8f58-2b20e175356e.png">

<img width="743" alt="image" src="https://user-images.githubusercontent.com/134939/215671198-8445b681-4498-4852-a8c3-3ad0e409a8e3.png">

<img width="759" alt="image" src="https://user-images.githubusercontent.com/134939/215671234-0b284215-1ee5-48d7-b50c-67f784367e8d.png">

## Links when clicked are selected and can be copied

<img width="764" alt="image" src="https://user-images.githubusercontent.com/134939/215671612-de3fa996-bb21-4f1f-9e2a-5addd518797a.png">

## How to add a link to the settings

1. The `id` must begin with `anuppuccin-url-`
2. The `description` must be the URL
3. Set `type` to `variable-text`
4. Set `default` to `'0'`

```yml
  -
    id: anuppuccin-url-something
    title: Setting Title
    description: https://website.com/snippet.css
    type: variable-text
    default: '0'
```

