### PR TITLE
fix level 0 settings

### DIFF
--- a/src/modules/Plugins/style-settings.scss
+++ b/src/modules/Plugins/style-settings.scss
@@ -5,14 +5,6 @@
 .style-settings-container:empty {
   display: none;
 }
-.style-settings-container:not([data-level="0"]) {
-  border: 1px solid rgba(var(--ctp-text), 0.2);
-  border-radius: var(--radius-s);
-  padding: var(--size-4-2);
-  padding-left: var(--size-4-6);
-  background-color: rgba(var(--ctp-crust), 0.3);
-}
-
 .style-settings-heading[data-level] {
   padding-top: var(--size-4-2);
   padding-bottom: var(--size-4-2);
@@ -20,15 +12,22 @@
 .style-settings-heading[data-level="0"]:not(.is-collapsed) {
   margin-bottom: var(--size-4-2);
 }
-.style-settings-heading:not([data-level="0"], .is-collapsed) {
-  margin-bottom: 0;
-}
-.style-settings-heading[data-level="0"]:not(.is-collapsed) + .style-settings-container {
-  border-bottom: 1px solid var(--background-modifier-border);
-}
 .style-settings-heading:not([data-level="0"]) {
   border-top: 1px solid rgba(var(--ctp-text), 0.2);
   border-bottom: none;
+}
+.style-settings-heading:not([data-level="0"], .is-collapsed) {
+  margin-bottom: 0;
+}
+.style-settings-heading:not([data-level="0"]) + .style-settings-container {
+  border: 1px solid rgba(var(--ctp-text), 0.2);
+  border-radius: var(--radius-s);
+  padding: var(--size-4-2);
+  padding-left: var(--size-4-6);
+  background-color: rgba(var(--ctp-crust), 0.3);
+}
+.style-settings-heading[data-level="0"]:not(.is-collapsed) + .style-settings-container {
+  border-bottom: 1px solid var(--background-modifier-border);
 }
 .style-settings-heading[data-level="1"] {
   border-top-color: var(--background-modifier-border);


### PR DESCRIPTION
Style Settings v1.0.0 (released today) removed data-level attributes from `.style-settings-container` elements. This breaks level-0 container styling. 

This pull request fixes it.

## Broken

<img width="676" alt="Screenshot 2023-02-02 at 01 01 53" src="https://user-images.githubusercontent.com/134939/216244372-9c86a164-dfb8-468a-a338-5b9d26991886.png">

## Fixed

<img width="682" alt="Screenshot 2023-02-02 at 01 01 07" src="https://user-images.githubusercontent.com/134939/216244384-94ca5edb-6786-47b2-8f28-11b28789c5aa.png">
