### PR TITLE
restrict heading colors to documents

### DIFF
--- a/src/modules/Note/headers.scss
+++ b/src/modules/Note/headers.scss
@@ -12,7 +12,7 @@ $accents: "rosewater", "flamingo", "pink", "mauve", "red", "maroon", "peach", "y
 @for $i from 1 through 6 {
   @each $accent in $accents {
     .anp-header-color-toggle {
-      &.anp-h#{$i}-#{$accent} {
+      &.anp-h#{$i}-#{$accent} .app-container {
         --h#{$i}-color: rgb(var(--ctp-#{$accent}));
       }
     }


### PR DESCRIPTION
## Before

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/134939/218655781-4eef08b9-93f8-4ef2-8631-7488358e923a.png">

## After

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/134939/218655879-d4992cc6-5d77-48ba-b1b9-6cfcc37e968c.png">
