### PR TITLE
fix vertical scrolling of codeblocks in Live Preview editor

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -3566,6 +3566,7 @@ body.is-translucent {
 .anp-codeblock-edit-nowrap .markdown-source-view.mod-cm6 .HyperMD-codeblock.cm-line {
   white-space: nowrap;
   overflow-x: scroll;
+  overflow-y: hidden;
 }
 .anp-codeblock-edit-nowrap .markdown-source-view.mod-cm6 .HyperMD-codeblock.cm-line::-webkit-scrollbar {
   display: none;

--- a/src/modules/Note/codeblocks.scss
+++ b/src/modules/Note/codeblocks.scss
@@ -12,6 +12,7 @@
   .markdown-source-view.mod-cm6 .HyperMD-codeblock.cm-line {
     white-space: nowrap;
     overflow-x: scroll;
+    overflow-y: hidden;
     &::-webkit-scrollbar {
       display: none;
     }

--- a/theme.css
+++ b/theme.css
@@ -3566,6 +3566,7 @@ body.is-translucent {
 .anp-codeblock-edit-nowrap .markdown-source-view.mod-cm6 .HyperMD-codeblock.cm-line {
   white-space: nowrap;
   overflow-x: scroll;
+  overflow-y: hidden;
 }
 .anp-codeblock-edit-nowrap .markdown-source-view.mod-cm6 .HyperMD-codeblock.cm-line::-webkit-scrollbar {
   display: none;


### PR DESCRIPTION
The scrolling sticks when scrolling down a page in Live Preview mode with the cursor over a long codeblock.

This fixes  it.