### PR TITLE
only apply px unit to radius and spacing kanban settings

### DIFF
--- a/src/modules/Plugins/style-settings.scss
+++ b/src/modules/Plugins/style-settings.scss
@@ -146,23 +146,8 @@
   content: '%';
 }
 
-.style-settings-container .setting-item:is(
-  [data-id*="anp-kanban-card-"],
-  [data-id*="anp-kanban-lane-"]
-) {
-  .setting-item-description {
-    width: fit-content;
-    display: flex;
-    &::after {
-      content: 'px';
-      margin-left: 2px;
-      padding: 2px;
-      margin-top: -1px;
-      border-radius: 4px;
-      background: var(--background-secondary-alt);
-      font-size: smaller;
-    }
-  }
+.setting-item[data-id*="anp-kanban-"]:is([data-id$="spacing"],[data-id$="radius"]) .setting-item-description small::after {
+  content: 'px';
 }
 
 


### PR DESCRIPTION
I also simplified the unit to match the default style in other settings.

For example:

<img width="550" alt="image" src="https://user-images.githubusercontent.com/134939/219995253-fea140c1-e0a7-4ef0-a220-8a464ad16ab0.png">

<img width="549" alt="image" src="https://user-images.githubusercontent.com/134939/219995218-7c5c7bbc-ca3a-4b90-96b3-384eb637c646.png">
