### PR TITLE
add kanban border settings

### DIFF
--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -714,18 +714,27 @@ settings:
     type: heading
     level: 2
     collapsed: true
+
+# Integrations :: Kanban :: Card Settings
+
   -
-    id: anp-kanban-lanes
-    title: Enable Full Height Lanes
-    description: Toggles maximum height for Kanban lanes
-    type: class-toggle
+    id: anp-plugin-card-settings
+    title: Card Settings
+    description: 
+    type: heading
+    level: 3
+    collapsed: true
   -
     id: anp-kanban-hide-card-menus
     title: Hide the Card Menu Button
     type: class-toggle
   -
-    id: anp-kanban-archive-btn
+    id: anp-kanban-hide-archive-btn
     title: Hide the Archive Card Button
+    type: class-toggle
+  -
+    id: anp-kanban-hide-card-border
+    title: Disable Card Borders
     type: class-toggle
   -
     id: anp-kanban-card-opacity
@@ -753,6 +762,25 @@ settings:
     min: -1
     max: 8
     step: 1
+
+# Integrations :: Kanban :: Lane Settings
+
+  -
+    id: anp-plugin-lane-settings
+    title: Lane Settings
+    description: 
+    type: heading
+    level: 3
+    collapsed: true
+  -
+    id: anp-kanban-lanes
+    title: Enable Full Height Lanes
+    description: Toggles maximum height for Kanban lanes
+    type: class-toggle
+  -
+    id: anp-kanban-hide-lane-border
+    title: Disable Lane Borders
+    type: class-toggle
   -
     id: anp-kanban-lane-opacity
     title: Lane Opacity

--- a/src/modules/Plugins/kanban/base.scss
+++ b/src/modules/Plugins/kanban/base.scss
@@ -56,16 +56,16 @@ body:not(.is-mobile):not(.anp-hide-status-bar) .kanban-plugin__board > div {
   }
 }
 .kanban-plugin button.kanban-plugin__new-item-button {
-    font-size: .875rem;
-    gap: 0.25em;
-    height: auto;
-    line-height: var(--line-height-tight);
-    padding: 7px 10px;
-  }
+  font-size: .875rem;
+  gap: 0.25em;
+  height: auto;
+  line-height: var(--line-height-tight);
+  padding: 7px 10px;
+}
 
 /* Kanban lane card counts */
 .kanban-plugin .kanban-plugin__lane-title-count {
-  background-color: var(--background-modifier-border);
+  background-color: var(--background-modifier-hover);
   border-radius: 2em;
   flex-shrink: 0;
   font-size: 12px;

--- a/src/modules/Plugins/kanban/buttons.scss
+++ b/src/modules/Plugins/kanban/buttons.scss
@@ -4,10 +4,10 @@
   }
 }
 
-.setting-item[data-id="anp-kanban-hide-card-menus"]:not(:has(.is-enabled)) + [data-id="anp-kanban-archive-btn"] {
+.setting-item[data-id="anp-kanban-hide-card-menus"]:not(:has(.is-enabled)) + [data-id="anp-kanban-hide-archive-btn"] {
   display: none;
 }
-.anp-kanban-hide-card-menus.anp-kanban-archive-btn {
+.anp-kanban-hide-card-menus.anp-kanban-hide-archive-btn {
   &:not(.is-mobile) .kanban-plugin__item-title-wrapper {
     padding: 8px;
     position: relative;

--- a/src/modules/Plugins/kanban/cards.scss
+++ b/src/modules/Plugins/kanban/cards.scss
@@ -1,0 +1,21 @@
+.anp-kanban-hide-card-border {
+  .kanban-plugin {
+    .kanban-plugin__item {
+      border-width: 0;
+    }
+    .kanban-plugin__item:hover .kanban-plugin__item-content-wrapper {
+      border-radius: var(--anp-kanban-card-radius, 6px);
+      box-shadow: inset 0 0 0 1px var(--background-modifier-border-hover);
+    }
+  }
+  .kanban-plugin__drag-container > .kanban-plugin__item-wrapper {
+    .kanban-plugin__item {
+      border-width: 0;
+      box-shadow: var(--shadow-s);
+    }
+    .kanban-plugin__item-content-wrapper {
+      border-radius: var(--anp-kanban-card-radius, 6px);
+      box-shadow: inset 0 0 0 1px var(--interactive-accent);
+    }
+  }
+}

--- a/src/modules/Plugins/kanban/index.scss
+++ b/src/modules/Plugins/kanban/index.scss
@@ -1,3 +1,5 @@
 @import "base.scss";
 @import "buttons.scss";
+@import "cards.scss";
 @import "lanes.scss";
+

--- a/src/modules/Plugins/kanban/lanes.scss
+++ b/src/modules/Plugins/kanban/lanes.scss
@@ -4,3 +4,17 @@
 .anp-kanban-lanes .kanban-plugin__scroll-container.kanban-plugin__vertical {
   flex-grow: 1;
 }
+.anp-kanban-hide-lane-border {
+  .kanban-plugin {
+    .kanban-plugin__lane,
+    .kanban-plugin__lane-header-wrapper,
+    .kanban-plugin__item-button-wrapper,
+    .kanban-plugin__item-form {
+        border-width: 0;
+    }
+    .kanban-plugin__lane-items {
+        padding-bottom: 0;
+        padding-top: 0;
+    }
+  }
+}


### PR DESCRIPTION
Sorry for all the pull requests, this should be the last one today... 😅

I added settings to hide the lane and card borders. For example, the Things theme removes the lane borders, so some people might prefer it.

The settings were getting pretty long with these extra options so I thought now it would make sense to group them.

WDYT?

<img width="755" alt="image" src="https://user-images.githubusercontent.com/134939/220009931-7d8d8baf-90e0-4792-a89f-41f2de361ea3.png">

