### PR TITLE
add a border only option to active line highlight

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -370,6 +370,9 @@ settings:
       -
         label: Highlight + Border
         value: anp-current-line-border
+      -
+        label: Border Only
+        value: anp-current-line-border-only
 
 # File Editor & Markdown Elements :: Callouts
   -
@@ -3152,6 +3155,19 @@ body.theme-dark {
   border-left: 2px solid var(--interactive-accent);
   margin-left: -2px !important;
   background-color: rgba(var(--ctp-surface1), 0.4);
+}
+
+.anp-current-line-border-only .markdown-source-view .cm-active.cm-line::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -1.5rem;
+  width: 2px;
+  background-color: rgba(var(--interactive-accent-rgb), 0.3);
+}
+.anp-current-line-border-only .markdown-source-view .cm-focused .cm-active.cm-line::before {
+  background-color: var(--interactive-accent);
 }
 
 /*-Custom editor font-*/

--- a/src/modules/Base/editor.scss
+++ b/src/modules/Base/editor.scss
@@ -11,6 +11,20 @@
     background-color: rgba(var(--ctp-surface1), 0.4);
   }
 }
+.anp-current-line-border-only .markdown-source-view {
+  .cm-active.cm-line::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -1.5rem;
+    width: 2px;
+    background-color: rgba(var(--interactive-accent-rgb), 0.3);
+  }
+  .cm-focused .cm-active.cm-line::before {
+    background-color: var(--interactive-accent);
+  }
+}
 /*-Custom editor font-*/
 .markdown-source-view:not(.is-live-preview) {
   --font-text: var(--anp-editor-font-source, var(--font-text-override)), var(--font-text-theme), var(--font-interface);

--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -369,6 +369,9 @@ settings:
       -
         label: Highlight + Border
         value: anp-current-line-border
+      -
+        label: Border Only
+        value: anp-current-line-border-only
 
 # File Editor & Markdown Elements :: Callouts
   -

--- a/theme.css
+++ b/theme.css
@@ -370,6 +370,9 @@ settings:
       -
         label: Highlight + Border
         value: anp-current-line-border
+      -
+        label: Border Only
+        value: anp-current-line-border-only
 
 # File Editor & Markdown Elements :: Callouts
   -
@@ -3152,6 +3155,19 @@ body.theme-dark {
   border-left: 2px solid var(--interactive-accent);
   margin-left: -2px !important;
   background-color: rgba(var(--ctp-surface1), 0.4);
+}
+
+.anp-current-line-border-only .markdown-source-view .cm-active.cm-line::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -1.5rem;
+  width: 2px;
+  background-color: rgba(var(--interactive-accent-rgb), 0.3);
+}
+.anp-current-line-border-only .markdown-source-view .cm-focused .cm-active.cm-line::before {
+  background-color: var(--interactive-accent);
 }
 
 /*-Custom editor font-*/


### PR DESCRIPTION
Here is an example of what this does:

![an example of the border only option](https://github.com/AnubisNekhet/AnuPpuccin/assets/24886086/77c6b1e7-df8f-420d-99be-2b786b235a24)

