### PR TITLE
Improve Hide Border and Enable Shadows for Menu

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -4012,6 +4012,9 @@ body.anp-card-layout {
 body.anp-card-layout.anp-hide-borders {
   --tab-outline-color: transparent;
 }
+.anp-card-layout.anp-hide-borders .menu {
+  border: 0px !important;  /*hide menu border*/
+}
 body.anp-card-layout .sidebar-toggle-button, body.anp-card-layout .workspace-tabs.mod-top {
   --tab-container-background: var(--card-background-color);
 }
@@ -4090,7 +4093,11 @@ body.anp-card-layout .workspace-split .workspace-leaf-content:not([data-type=fil
   margin-bottom: var(--anp-card-layout-padding, 10px);
 }
 body.anp-card-layout.anp-card-shadows .workspace-split .workspace-leaf-content, body.anp-card-layout.anp-card-shadows.anp-card-layout-actions .side-dock-actions, body.anp-card-layout.anp-card-shadows.anp-card-layout-filebrowser .workspace-split .workspace-leaf-content[data-type=file-explorer] {
-  box-shadow: 0 3px 4px 0px rgba(0, 0, 0, 0.05);
+  box-shadow: 0px 3px 4px 0px rgba(0, 0, 0, 0.05);
+}
+body.anp-card-layout.anp-card-shadows .menu {
+  box-shadow: 3px 3px 4px 0px rgba(0, 0, 0, 0.05), -3px 3px 4px 0px rgba(0, 0, 0, 0.05);  /*add shadow for menu*/
+
 }
 body.anp-card-layout .workspace-split .mod-stacked .workspace-leaf-content {
   border-radius: 0;

--- a/theme.css
+++ b/theme.css
@@ -4095,10 +4095,6 @@ body.anp-card-layout .workspace-split .workspace-leaf-content:not([data-type=fil
 body.anp-card-layout.anp-card-shadows .workspace-split .workspace-leaf-content, body.anp-card-layout.anp-card-shadows.anp-card-layout-actions .side-dock-actions, body.anp-card-layout.anp-card-shadows.anp-card-layout-filebrowser .workspace-split .workspace-leaf-content[data-type=file-explorer] {
   box-shadow: 0px 3px 4px 0px rgba(0, 0, 0, 0.05);
 }
-body.anp-card-layout.anp-card-shadows .menu {
-  box-shadow: 3px 3px 4px 0px rgba(0, 0, 0, 0.05), -3px 3px 4px 0px rgba(0, 0, 0, 0.05);  /*add shadow for menu*/
-
-}
 body.anp-card-layout .workspace-split .mod-stacked .workspace-leaf-content {
   border-radius: 0;
   border: none;


### PR DESCRIPTION
Now, toggling "hide border" will hide the border for the menu, and "enable shadows" for the menu, too.

I think these changes can make the theme more uniform. You can close the PR for free if you don't like the changes. Please forgive me if there are any irregularities, as I am a PR novice🥲.

The final result is shown in the following figure:

<img width="487" alt="image" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/93238080/6b5f8543-9f79-4b94-a5aa-bdca8997380c">
