### PR TITLE
fix file-tree alignment

### DIFF
--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -2100,8 +2100,8 @@ settings:
     level: 2
     collapsed: true
   -
-    id: anp-collapse-folders
-    title: Enable folder icons for collapse indicators
+    id: anp-custom-vault-toggle
+    title: Enable custom vault title
     type: class-toggle
   -
     id: anp-file-icons
@@ -2112,8 +2112,8 @@ settings:
     title: Enable floating vault title
     type: class-toggle
   -
-    id: anp-custom-vault-toggle
-    title: Enable custom vault title
+    id: anp-collapse-folders
+    title: Enable folder icons for collapse indicators
     type: class-toggle
   -
     id: anp-file-label-align
@@ -2127,18 +2127,6 @@ settings:
       -
         label: Left
         value: 0
-  -
-    id: anp-file-icon-align
-    title: File Icon Alignment
-    type: variable-select
-    default: '0'
-    options:
-      - 
-        label: Default
-        value: 0
-      - 
-        label: Aligned
-        value: '-17px'
 
 # Workspace :: PDF Viewer
 

--- a/src/modules/Features/collapse-folders.scss
+++ b/src/modules/Features/collapse-folders.scss
@@ -1,19 +1,23 @@
-.anp-collapse-folders {
-    .nav-folder .nav-folder-collapse-indicator,
-    [data-type="bookmarks"] .tree-item .collapse-icon {
+.anp-collapse-folders .workspace-leaf-content:not([data-type="search"]) {
+  .nav-folder.mod-root .nav-folder > .nav-folder-children :is(.nav-file,.nav-folder) {
+    margin-left: var(--size-2-1);
+  }
+  .tree-item .nav-folder-title {
+    align-items: center;
+  }
+  .tree-item .collapse-icon {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 27 24' fill='none' stroke='currentColor' stroke-linejoin='round' stroke-linecap='round' stroke-width='2'%3E%3Cpath d='M6 14l1.45-2.9A2 2 0 0 1 9.24 10H22a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H20a2 2 0 0 1 2 2v2'/%3E%3C/svg%3E%0A");
     -webkit-mask-repeat: no-repeat;
     background-color: currentColor;
+    display: flex;
+    flex-basis: 100%;
     height: 16px;
     width: 17px;
-    margin-right: 4px;
   }
-  .nav-folder.is-collapsed .nav-folder-collapse-indicator,
-  [data-type="bookmarks"] .tree-item.is-collapsed .collapse-icon {
+  .tree-item.is-collapsed .collapse-icon {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 27 24' fill='none' stroke='currentColor' stroke-linejoin='round' stroke-linecap='round' stroke-width='2'%3E%3Cpath d='M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2z'/%3E%3Cpath d='M2 10h20' /%3E%3C/svg%3E%0A");
   }
-  .nav-folder-collapse-indicator svg.svg-icon,
-  [data-type="bookmarks"] .collapse-icon svg.svg-icon {
-    color: transparent !important;
+  .tree-item .collapse-icon svg {
+    display: none;
   }
 }

--- a/src/modules/Features/file-icons.scss
+++ b/src/modules/Features/file-icons.scss
@@ -1,22 +1,26 @@
+.anp-file-icons .nav-file .nav-file-title[data-path] {
+  align-items: center;
+}
 .anp-file-icons .nav-file .nav-file-title[data-path]::before {
-	-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpath d='M14 2v6h6'/%3E%3C/svg%3E%0A");
-	-webkit-mask-repeat: no-repeat;
-	background-color: currentColor;
-	content: "";
-	display: inline-flex;
-	flex-shrink: 0;
-	height: 16px;
-	width: 16px;
-	margin-right: 5px;
-	margin-left: var(--anp-file-icon-align, 0px);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpath d='M14 2v6h6'/%3E%3C/svg%3E%0A");
+  -webkit-mask-repeat: no-repeat;
+  background-color: var(--icon-color);
+  content: '';
+  display: flex;
+  flex-shrink: 0;
+  height: var(--size-4-4);
+  margin-left: calc(-1 * var(--size-4-5));
+  opacity: var(--icon-opacity);
+  position: absolute;
+  width: var(--size-4-4);
 }
 .anp-file-icons .nav-file .nav-file-title[data-path$=".md"]::before {
-	-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpath d='M14 2v6h6m-4 5H8m8 4H8m2-8H8'/%3E%3C/svg%3E%0A");
-	-webkit-mask-repeat: no-repeat;
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpath d='M14 2v6h6m-4 5H8m8 4H8m2-8H8'/%3E%3C/svg%3E%0A");
+    -webkit-mask-repeat: no-repeat;
 }
 .anp-file-icons .nav-file .nav-file-title[data-path$=".canvas"]::before {
-	-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 3h7v9H3zm11 0h7v5h-7zm0 9h7v9h-7zM3 16h7v5H3z'/%3E%3C/svg%3E");
-	-webkit-mask-repeat: no-repeat;
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 3h7v9H3zm11 0h7v5h-7zm0 9h7v9h-7zM3 16h7v5H3z'/%3E%3C/svg%3E");
+    -webkit-mask-repeat: no-repeat;
 }
 .anp-file-icons .nav-file .nav-file-title[data-path$=".svg"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".bmp"]::before,
@@ -25,8 +29,8 @@
 .anp-file-icons .nav-file .nav-file-title[data-path$=".webp"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".jpeg"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".png"]::before {
-	-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpath d='M14 2v6h6'/%3E%3Ccircle cx='10' cy='13' r='2'/%3E%3Cpath d='m20 17-1.09-1.09a2 2 0 0 0-2.82 0L10 22'/%3E%3C/svg%3E%0A");
-	-webkit-mask-repeat: no-repeat;
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpath d='M14 2v6h6'/%3E%3Ccircle cx='10' cy='13' r='2'/%3E%3Cpath d='m20 17-1.09-1.09a2 2 0 0 0-2.82 0L10 22'/%3E%3C/svg%3E%0A");
+    -webkit-mask-repeat: no-repeat;
 }
 .anp-file-icons .nav-file .nav-file-title[data-path$=".mp3"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".wav"]::before,
@@ -34,24 +38,17 @@
 .anp-file-icons .nav-file .nav-file-title[data-path$=".ogg"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".flac"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".3gp"]::before {
-	-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 18V5l12-2v13M9 9l12-2'/%3E%3Ccircle cx='6' cy='18' r='3'/%3E%3Ccircle cx='18' cy='16' r='3'/%3E%3C/svg%3E");
-	-webkit-mask-repeat: no-repeat;
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 18V5l12-2v13M9 9l12-2'/%3E%3Ccircle cx='6' cy='18' r='3'/%3E%3Ccircle cx='18' cy='16' r='3'/%3E%3C/svg%3E");
+    -webkit-mask-repeat: no-repeat;
 }
 .anp-file-icons .nav-file .nav-file-title[data-path$=".webm"]::before {
-	-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M10 8l6 4-6 4V8z'/%3E%3C/svg%3E");
-	-webkit-mask-repeat: no-repeat;
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M10 8l6 4-6 4V8z'/%3E%3C/svg%3E");
+    -webkit-mask-repeat: no-repeat;
 }
 .anp-file-icons .nav-file .nav-file-title[data-path$=".mp4"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".ogv"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".mov"]::before,
 .anp-file-icons .nav-file .nav-file-title[data-path$=".mkv"]::before {
-	-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 11v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8H4Z'/%3E%3Cpath d='m4 11-.88-2.87a2 2 0 0 1 1.33-2.5l11.48-3.5a2 2 0 0 1 2.5 1.32l.87 2.87L4 11.01Z'/%3E%3Cpath d='M6.6 4.99l3.38 4.2m1.88-5.81l3.38 4.2'/%3E%3C/svg%3E");
-	-webkit-mask-repeat: no-repeat;
-}
-.anp-file-icons
-	.nav-folder.mod-root
-	> .nav-folder-children
-	> .nav-file
-	.nav-file-title {
-	padding-left: var(--size-4-2);
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 11v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8H4Z'/%3E%3Cpath d='m4 11-.88-2.87a2 2 0 0 1 1.33-2.5l11.48-3.5a2 2 0 0 1 2.5 1.32l.87 2.87L4 11.01Z'/%3E%3Cpath d='M6.6 4.99l3.38 4.2m1.88-5.81l3.38 4.2'/%3E%3C/svg%3E");
+    -webkit-mask-repeat: no-repeat;
 }


### PR DESCRIPTION
This is how Obsidian aligns the file-tree by default. It may look misaligned when expanded because of the vertical lines, but it's actually not as the file names line up with the folder names. 

<img width="245" alt="image" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/ad224375-0abb-41cb-8feb-9763ab996f48">

<img width="248" alt="image" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/ef7543a7-b048-447e-abe7-38c31af87c9c">

This fix ensures the file-tree remains visually aligned **when file icons are enabled** (since that what issue #215 was about).

"Visually aligned" meaning the folder/file names remain aligned like this:

<img alt="image" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/8b123ff8-bad4-450c-b84a-882f7ec80041">

Here with file icons enabled:

<img width="243" alt="image" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/fb2f59da-393c-40e3-b6fd-15b0f9dfe919">

<img width="243" alt="image" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/33a6c728-0e9d-42ac-81eb-f29777b5354b">

And also here with both folder/file icons enabled:

<img width="246" alt="image" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/a8bd241c-f399-4ab5-9291-440ca5f57f2d">

<img width="244" alt="image" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/9e2be533-04f4-4144-9a5f-ec68b4037f89">

Because this issue is only related to file icon alignment, I have removed the "File Icon Alignment" option since I don't think it's necessary (file icons should be aligned by default and they shouldn't change the file-tree layout when enabled).
