### PR TITLE
Fix/rainbow folders

### DIFF
--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -2222,16 +2222,12 @@ settings:
     title: Enable title recolor
     type: class-toggle
   -
-    id: anp-simple-rainbow-icon-folder-toggle
-    title: Enable icon recolor (For icon folder users)
+    id: anp-simple-rainbow-collapse-icon-toggle
+    title: Enable collapse icon recolor
     type: class-toggle
   -
     id: anp-simple-rainbow-indentation-toggle
     title: Enable collapse indent recolor
-    type: class-toggle
-  -
-    id: anp-simple-rainbow-collapse-toggle
-    title: Enable collapse indicator
     type: class-toggle
   -
     id: anp-simple-rainbow-icon-toggle

--- a/src/modules/Features/Rainbow-File-Browser/fullrainbow.scss
+++ b/src/modules/Features/Rainbow-File-Browser/fullrainbow.scss
@@ -5,6 +5,7 @@
 	// Apply styling to folders
 	.nav-folder.mod-root > .nav-folder-children > .nav-folder .nav-folder-title,
 	.nav-folder.mod-root > .nav-folder-children > .nav-folder .nav-file-title,
+	.nav-folder.mod-root .collapse-icon svg.svg-icon,
 	.tree-item-self .tree-item-icon {
 		color: var(--anp-full-rainbow-text-inverted, var(--background-primary));
 	}

--- a/src/modules/Features/Rainbow-File-Browser/simplerainbow.scss
+++ b/src/modules/Features/Rainbow-File-Browser/simplerainbow.scss
@@ -5,11 +5,7 @@
 	// Apply styling to titles
 	&.anp-simple-rainbow-title-toggle {
 		.nav-folder.mod-root > .nav-folder-children > .nav-folder .nav-folder-title,
-		[data-type="bookmarks"]
-			> .view-content
-			> div
-			> .tree-item
-			.tree-item-inner {
+		[data-type="bookmarks"] .tree-item .tree-item-inner {
 			transition: color 0.4s;
 			color: rgba(
 				var(--rainbow-folder-color),
@@ -21,15 +17,8 @@
 	}
 	// Circle icon indicator
 	&.anp-simple-rainbow-icon-toggle {
-		.nav-folder.mod-root
-			> .nav-folder-children
-			> .nav-folder
-			.nav-folder-title:after,
-		[data-type="bookmarks"]
-			> .view-content
-			> div
-			> .tree-item
-			.tree-item-inner:after {
+		.nav-folder.mod-root > .nav-folder-children > .nav-folder .nav-folder-title:after,
+		[data-type="bookmarks"] .tree-item .tree-item-inner:after {
 			transition: color 0.4s;
 			color: rgba(
 				var(--rainbow-folder-color),
@@ -40,16 +29,19 @@
 			position: relative;
 			margin-left: 4px;
 			opacity: 0.5;
+			top: -0.5px
+		}
+		[data-type="bookmarks"] .tree-item .tree-item-inner {
+		    align-items: center;
+		    display: flex;
+		    flex-grow: 1;
+		    justify-content: space-between;
 		}
 	}
 	// Color indents
 	&.anp-simple-rainbow-indentation-toggle {
 		.nav-folder.mod-root .nav-folder > .nav-folder-children,
-		[data-type="bookmarks"]
-			> .view-content
-			> div
-			> .tree-item
-			.tree-item-children {
+		[data-type="bookmarks"] .tree-item .tree-item-children {
 			transition: color 0.4s;
 			border-color: rgba(var(--rainbow-folder-color), 0.5);
 		}

--- a/src/modules/Features/Rainbow-File-Browser/simplerainbow.scss
+++ b/src/modules/Features/Rainbow-File-Browser/simplerainbow.scss
@@ -55,7 +55,7 @@
 		}
 	}
 	// Color Collapse Indicators
-	&.anp-simple-rainbow-collapse-toggle {
+	&.anp-simple-rainbow-collapse-icon-toggle {
 		.tree-item-self .tree-item-icon {
 			--icon-color: rgba(
 				var(--rainbow-folder-color),

--- a/src/modules/Features/Rainbow-File-Browser/simplerainbow.scss
+++ b/src/modules/Features/Rainbow-File-Browser/simplerainbow.scss
@@ -36,9 +36,9 @@
 				var(--anp-simple-rainbow-opacity, 1)
 			);
 			content: "⬤";
+			font-size: 10px;
 			position: relative;
 			margin-left: 4px;
-			top: 1px;
 			opacity: 0.5;
 		}
 	}


### PR DESCRIPTION
## Fixes collapse indicator color in full rainbow style

Before:
<img width="238" alt="Screenshot 2023-10-27 at 12 32 29" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/557cee9e-81c3-4ecc-b522-2f7279175151">

After:
<img width="242" alt="Screenshot 2023-10-27 at 12 33 24" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/5e16a13e-51df-47b6-82b8-548ab7645ce1">

## Merges "Enable icon recolor" and "Enable collapse indicator" options into a single option:

The "Enable icon recolor (For icon folder users)" option wasn't working anyway.

Before:
<img width="694" alt="Screenshot 2023-10-27 at 12 36 32" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/3e4bb874-e8ab-451f-8e94-b445c6a3108f">

After:
<img width="687" alt="Screenshot 2023-10-27 at 12 37 05" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/44b5ffe7-8d7a-4998-93cc-d63378068cf0">

## Made the circle indicator smaller and centered. 

Before:
<img width="246" alt="Screenshot 2023-10-27 at 12 37 40" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/50af1df0-9023-413c-b628-6fa88f1a93ac">

After:
<img width="242" alt="Screenshot 2023-10-27 at 12 37 58" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/66158bfa-2639-4a98-bf22-04b09aeb7d1d">

## Fixed alignment of circles in bookmarks.

Before:
<img width="245" alt="Screenshot 2023-10-27 at 13 56 37" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/a656fc91-d654-4c9c-b84c-53b609edb72a">

After:
<img width="240" alt="image" src="https://github.com/AnubisNekhet/AnuPpuccin/assets/134939/1318d27a-d82c-4248-87e5-dd2c13b67bc8">
