### PR TITLE
fix padding asymmetry between vertical tabs in card layout

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -4126,10 +4126,21 @@ body.anp-card-layout .workspace-tab-header-container,
 body.anp-card-layout .workspace-ribbon.mod-left:before {
   border-bottom: none;
 }
-body.anp-card-layout .mod-vertical .workspace-tabs {
-  padding-left: var(--anp-card-layout-padding, 10px);
-  padding-right: var(--anp-card-layout-padding, 10px);
+
+body.anp-card-layout .mod-vertical {
+    gap: var(--anp-card-layout-padding, 10px);
 }
+
+body.anp-card-layout .mod-vertical {
+    padding-left: var(--anp-card-layout-padding, 10px);
+    padding-right: var(--anp-card-layout-padding, 10px);
+}
+
+body.anp-card-layout .mod-vertical .mod-vertical {
+    padding-left: 0;
+    padding-right: 0;
+}
+
 body.anp-card-layout .mod-vertical .workspace-tabs .workspace-tab-header-container {
   padding-left: var(--anp-card-header-left-padding, 20px);
 }


### PR DESCRIPTION
There was an asymmetry in the space at the center of two tabs when they were stacked in a vertical layout (in the card layout), since each tab had a padding on both the left and right, and so the center one would accumulate.

This is the screenshot before:
![Screenshot 2024-06-05 at 12 40 46 PM](https://github.com/AnubisNekhet/AnuPpuccin/assets/44399141/63cc4975-74fa-42f3-8db2-f6bb20e8aa34)
And these are some screenshot after:
![Screenshot 2024-06-05 at 12 40 03 PM](https://github.com/AnubisNekhet/AnuPpuccin/assets/44399141/ff781ed1-23c4-43f1-80d5-8169eaec31d1)
![Screenshot 2024-06-05 at 12 42 16 PM](https://github.com/AnubisNekhet/AnuPpuccin/assets/44399141/1e339e42-8ff0-410a-b56b-db8b72b89db2)
![Screenshot 2024-06-05 at 12 42 25 PM](https://github.com/AnubisNekhet/AnuPpuccin/assets/44399141/d47311dc-f837-4f32-8066-b837849f32c8)

Now the vertical spacing on the left and right side is equal to the one in the center. If this can drive other people crazy apart from me, consider to merge it! 
Thanks for the amazing theme btw 🔥 