### PR TITLE
fix padding asymmetry between left and right sidebars w.r.t. tabs in card layout

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -4141,6 +4141,10 @@ body.anp-card-layout .mod-vertical .mod-vertical {
     padding-right: 0;
 }
 
+body.anp-card-layout div.workspace-split.mod-horizontal.mod-sidedock.mod-left-split .workspace-tab-container {
+    padding-right: 0px;
+}
+
 body.anp-card-layout .mod-vertical .workspace-tabs .workspace-tab-header-container {
   padding-left: var(--anp-card-header-left-padding, 20px);
 }

--- a/theme.css
+++ b/theme.css
@@ -4145,6 +4145,10 @@ body.anp-card-layout div.workspace-split.mod-horizontal.mod-sidedock.mod-left-sp
     padding-right: 0px;
 }
 
+body.anp-card-layout div.workspace-split.mod-horizontal.mod-sidedock.mod-right-split .workspace-tab-container {
+    padding-left: 0px;
+}
+
 body.anp-card-layout .mod-vertical .workspace-tabs .workspace-tab-header-container {
   padding-left: var(--anp-card-header-left-padding, 20px);
 }


### PR DESCRIPTION
5 minutes before the merge of #286 I noticed that the same problem of padding symmetry affects also the left and right sidebars with respect to the tabs, where the padding again doubles. I'm sorry I have to make a new pull request, but I was just now tinkering with the settings, and It wasn't visible when I had the file browser not as a card.

Here is the screenshot before:
![Screenshot 2024-06-05 at 6 47 15 PM](https://github.com/AnubisNekhet/AnuPpuccin/assets/44399141/6d6324ec-b978-4e36-82a6-5327a1b1c01d)


And here is the after:
![Screenshot 2024-06-05 at 6 46 34 PM](https://github.com/AnubisNekhet/AnuPpuccin/assets/44399141/622e69f3-2ab3-4fe3-8994-411e5ecad9fa)


