### PR TITLE
fixes wrong number of arguments (1 of 3) for 'rgb' during sass build

### DIFF
--- a/src/modules/Features/floating-title.scss
+++ b/src/modules/Features/floating-title.scss
@@ -11,7 +11,7 @@ None of the original code was used and the feature was implemented from scratch.
   width: 100%;
   border: 1px solid var(--background-modifier-border);
   border-radius: var(--radius-s);
-  box-shadow: 0 3px 4px 0px rgb(0 0 0 / 5%);
+  box-shadow: 0 3px 4px 0px rgba(0, 0, 0, 5%);
 }
 .anp-floating-header.anp-card-layout .nav-folder.mod-root > .nav-folder-title {
   background-color: var(--card-foreground-color, var(--background-primary));

--- a/src/modules/Integrations/editing-toolbar.scss
+++ b/src/modules/Integrations/editing-toolbar.scss
@@ -1,6 +1,6 @@
 .cMenuToolbarDefaultAesthetic {
   margin: 5px 10px 0 10px;
-  box-shadow: 0 3px 4px 0px rgb(0 0 0 / 5%);
+  box-shadow: 0 3px 4px 0px rgba(0, 0, 0, 5%);
   background-color: var(--background-primary);
 }
 #cMenuToolbarModalBar.top button.cMenuToolbarCommandItem:hover {

--- a/src/modules/Workspace/Status-Bar/floating-status-bar.scss
+++ b/src/modules/Workspace/Status-Bar/floating-status-bar.scss
@@ -13,7 +13,7 @@ Support me: https://buymeacoffee.com/AnubisNekhet
 		transition: transform 300ms 150ms;
 		bottom: 5px;
 		right: 5px;
-		box-shadow: 0 3px 4px 0px rgba(0 0 0 / 5%);
+		box-shadow: 0 3px 4px 0px rgba(0, 0, 0, 5%);
 		&::before {
 			width: 100%;
 			min-height: 100%;


### PR DESCRIPTION
fixes #305 
I just replaced the `rgba` lines that threw error messages
tested on MacOS