### PR TITLE
Add a Zen Mode

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -17,6 +17,22 @@ name: AnuPpuccin
 id: anuppuccin-theme-settings
 settings:
 
+# WIP
+
+  -
+    id: anp-zen-mode-header
+    title: Zen Mode
+    description:
+    type: heading
+    level: 3
+    collapsed: false
+  -
+    id: anp-zen-mode
+    title: Enable Zen Mode
+    description: Hides top bar
+    type: class-toggle
+
+
 # Colors
 
   -
@@ -7135,6 +7151,19 @@ None of the original code was used and the feature was implemented from scratch.
   	var(--rainbow-folder-color),
   	var(--anp-simple-rainbow-opacity, 1)
   );
+}
+
+.anp-zen-mode:not(.is-fullscreen).is-focused .titlebar-button-container.mod-right {
+  background-color: var(--background-primary);
+}
+.anp-zen-mode:not(.is-fullscreen) .titlebar-button-container.mod-right {
+  background-color: var(--background-primary);
+}
+.anp-zen-mode .mod-root .workspace-tabs .workspace-tab-header-container {
+  display: none;
+}
+.anp-zen-mode .mod-root .workspace-tabs .workspace-tab-container .view-header {
+  display: none;
 }
 
 .modal {

--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -3,6 +3,22 @@ name: AnuPpuccin
 id: anuppuccin-theme-settings
 settings:
 
+# WIP
+
+  -
+    id: anp-zen-mode-header
+    title: Zen Mode
+    description:
+    type: heading
+    level: 3
+    collapsed: false
+  -
+    id: anp-zen-mode
+    title: Enable Zen Mode
+    description: Hides top bar
+    type: class-toggle
+
+
 # Colors
 
   -

--- a/src/modules/Features/index.scss
+++ b/src/modules/Features/index.scss
@@ -12,3 +12,4 @@
 @import "file-icons.scss";
 @import "metadata-mods.scss";
 @import "Rainbow-File-Browser/index.scss";
+@import "zen-mode.scss";

--- a/src/modules/Features/zen-mode.scss
+++ b/src/modules/Features/zen-mode.scss
@@ -1,0 +1,32 @@
+.anp-zen-mode {
+    &:not(.is-fullscreen) {
+        &.is-focused {
+            .titlebar-button-container {
+                &.mod-right {
+                    background-color: var(--background-primary);
+                }
+            }
+        }
+
+        .titlebar-button-container {
+            &.mod-right {
+                background-color: var(--background-primary);
+            }
+        }
+    }
+
+
+    .mod-root {
+        .workspace-tabs {
+            .workspace-tab-header-container {
+                display: none;
+            }
+
+            .workspace-tab-container {
+                .view-header {
+                    display: none;
+                }
+            }
+        }
+    }
+}

--- a/theme.css
+++ b/theme.css
@@ -17,6 +17,22 @@ name: AnuPpuccin
 id: anuppuccin-theme-settings
 settings:
 
+# WIP
+
+  -
+    id: anp-zen-mode-header
+    title: Zen Mode
+    description:
+    type: heading
+    level: 3
+    collapsed: false
+  -
+    id: anp-zen-mode
+    title: Enable Zen Mode
+    description: Hides top bar
+    type: class-toggle
+
+
 # Colors
 
   -
@@ -7135,6 +7151,19 @@ None of the original code was used and the feature was implemented from scratch.
   	var(--rainbow-folder-color),
   	var(--anp-simple-rainbow-opacity, 1)
   );
+}
+
+.anp-zen-mode:not(.is-fullscreen).is-focused .titlebar-button-container.mod-right {
+  background-color: var(--background-primary);
+}
+.anp-zen-mode:not(.is-fullscreen) .titlebar-button-container.mod-right {
+  background-color: var(--background-primary);
+}
+.anp-zen-mode .mod-root .workspace-tabs .workspace-tab-header-container {
+  display: none;
+}
+.anp-zen-mode .mod-root .workspace-tabs .workspace-tab-container .view-header {
+  display: none;
 }
 
 .modal {


### PR DESCRIPTION
as requested by #309

acts like Minimal and hides tabs bar & editor top bar

drafting the PR because it doesn't seem possible to add commands for a theme, so it's not possible to easily switch from normal to zen mode, you have to go into style settings to enable/disable it, which is far from optimal
i guess the theme would need a plugin companion to help with that