### PR TITLE
Add a toggle for external link icons

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1122,6 +1122,11 @@ settings:
     id: anp-tooltip-toggle
     title: Hide Tooltips
     type: class-toggle
+  -
+    id: anp-hide-external-link-icon
+    title: Hide External Link Icon
+    type: class-toggle
+    default: true
 
 # Typography
 
@@ -4658,8 +4663,8 @@ Support me: https://buymeacoffee.com/AnubisNekhet
   --link-decoration-active: none;
 }
 
-.external-link,
-.external-link:hover {
+.anp-hide-external-link-icon .external-link,
+.anp-hide-external-link-icon .external-link:hover {
   background-image: none;
   padding-right: 0px;
 }

--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -1108,6 +1108,11 @@ settings:
     id: anp-tooltip-toggle
     title: Hide Tooltips
     type: class-toggle
+  -
+    id: anp-hide-external-link-icon
+    title: Hide External Link Icon
+    type: class-toggle
+    default: true
 
 # Typography
 

--- a/src/modules/Markdown-Elements/decorations.scss
+++ b/src/modules/Markdown-Elements/decorations.scss
@@ -20,10 +20,12 @@
   --link-decoration-active: none;
 }
 // External links have underline but no icon
-.external-link,
-.external-link:hover {
-  background-image: none;
-  padding-right: 0px;
+.anp-hide-external-link-icon {
+  .external-link,
+  .external-link:hover {
+    background-image: none;
+    padding-right: 0px;
+  }
 }
 
 // Editor colors follow the same color as in reading mode

--- a/theme.css
+++ b/theme.css
@@ -1122,6 +1122,11 @@ settings:
     id: anp-tooltip-toggle
     title: Hide Tooltips
     type: class-toggle
+  -
+    id: anp-hide-external-link-icon
+    title: Hide External Link Icon
+    type: class-toggle
+    default: true
 
 # Typography
 
@@ -4658,8 +4663,8 @@ Support me: https://buymeacoffee.com/AnubisNekhet
   --link-decoration-active: none;
 }
 
-.external-link,
-.external-link:hover {
+.anp-hide-external-link-icon .external-link,
+.anp-hide-external-link-icon .external-link:hover {
   background-image: none;
   padding-right: 0px;
 }


### PR DESCRIPTION
as pointed out by #300, by default the theme gets rid of external link icons

the PR adds a toggle in style settings to get them back on

![image](https://github.com/user-attachments/assets/58b4abdc-6955-4f25-8bef-09a0adbd8802)

note: toggle is on by default to mimic the initial intend of the theme