### PR TITLE
More control over text colors

### DIFF
--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -1847,7 +1847,7 @@ settings:
     options:
       - 
         label: None
-        value: anp-bold-none
+        value: none
       - 
         label: Rosewater
         value: anp-bold-rosewater
@@ -1899,7 +1899,7 @@ settings:
     options:
       - 
         label: None
-        value: anp-bold-none
+        value: none
       - 
         label: Rosewater
         value: anp-italic-rosewater

--- a/src/modules/Core/style-settings.scss
+++ b/src/modules/Core/style-settings.scss
@@ -1842,9 +1842,12 @@ settings:
     id: anp-bold-custom
     title: Bold Color
     type: class-select
-    allowEmpty: true
+    allowEmpty: false
     default: anp-bold-red
     options:
+      - 
+        label: None
+        value: anp-bold-none
       - 
         label: Rosewater
         value: anp-bold-rosewater
@@ -1891,9 +1894,12 @@ settings:
     id: anp-italic-custom
     title: Italic Color
     type: class-select
-    allowEmpty: true
+    allowEmpty: false
     default: anp-italic-green
     options:
+      - 
+        label: None
+        value: anp-bold-none
       - 
         label: Rosewater
         value: anp-italic-rosewater
@@ -1940,7 +1946,7 @@ settings:
     id: anp-highlight-custom
     title: Highlight Color
     type: class-select
-    allowEmpty: true
+    allowEmpty: false
     default: anp-highlight-yellow
     options:
       - 

--- a/src/modules/Markdown-Elements/decorations.scss
+++ b/src/modules/Markdown-Elements/decorations.scss
@@ -1,7 +1,7 @@
 /*-Decorations for bold and italics-*/
 .anp-decoration-toggle {
-  --italic-color: rgb(var(--anp-italic-color, var(--ctp-green)));
-  --bold-color: rgb(var(--anp-bold-color, var(--ctp-red)));
+  --italic-color: rgb(var(--anp-italic-color, var(--text-normal)));
+  --bold-color: rgb(var(--anp-bold-color, var(--text-normal)));
   --text-highlight-bg: rgba(var(--anp-highlight-color, var(--ctp-yellow)), 0.2);
 }
 // Internal links have no underline


### PR DESCRIPTION
unless using custom css, it was not possible to use custom Decoration Color on one type of typo _(for example, if one wanted to color only bold text, but not italic, it was not possible)_

this PR aims to let people granularly choose their colors, with the option not to edit the color of a type

highlights still defaults to yellow colors but that's by design, wouldn't make sense to allow people to input blank colors for highlighting